### PR TITLE
1) Addressing the behavioral difference of regex package in different env

### DIFF
--- a/main/__init__.py
+++ b/main/__init__.py
@@ -1,3 +1,5 @@
+import os
+
 from data_transformer.data_manager_factory import DataManagerFactory
 from data_processor.performanceAnalizer import Performance_Analyzer
 from data_processor.configuration import Config
@@ -90,6 +92,8 @@ def handle_display(config):
         analyzer.display(entityCollection)
     else:
         analyzer.export(entityCollection)
+        print("Your exported file can be found in path: {}".format(os.path.join(os.getcwd(), "Summary.pdf")))
+
 
 
 def run():

--- a/main/data_transformer/abstract_parser.py
+++ b/main/data_transformer/abstract_parser.py
@@ -112,14 +112,21 @@ class Parser:
         This a simple helper class that stores the mathematical operands into existing expression list
         and store it in expression_collection.
 
+        The first line in the method is to attend the behavioral difference of regex package
+        in different editors and different environments.
+        Issue: In certain environment, after parsing 'A+B As C' returns A, B, C
+        while in others it returns A, B As C. So to address this, 'As' is checked and removed from list
+
         Adding operand into the list is useful when comes to calculating it.
         Also, this is made as a separate method for readability.
         As in previous methods adding + to match might confuse the readers.
 
-        :param expression_collection(list of string): [A,B,As,C]
+        :param expression_collection(list of string): [A,B,As,C] or [A,B,C]
         :param function(string): +
         :return: None
         """
+        expression_collection = [content for content in expression_collection if content.lower() != 'as']
+
         expression_collection.append(function)
         self.__parsed_expression_collection__.append(expression_collection)  
         

--- a/main/data_transformer/csv_parser.py
+++ b/main/data_transformer/csv_parser.py
@@ -32,7 +32,7 @@ class CsvParser(Parser):
         data = self.__validate__()
         fields = self.get_computable_fields()
         parsed_expressions = self.get_parsed_expression()
-        self.entityCollection.fields = list(fields) + [expression[3] for expression in self.get_parsed_expression()]
+        self.entityCollection.fields = list(fields) + [expression[2] for expression in self.get_parsed_expression()]
         for row in data:
             entity_object = self.entityCollection.add_entity(row[self.config.base_field])
             self.__handle_normal_fields__(row, fields, entity_object)
@@ -62,7 +62,7 @@ class CsvParser(Parser):
         """
         for expression in parsed_expressions:
             self.evaluate_expression(row[expression[0]], row[expression[1]],
-                                     expression[3], expression[4], entity_object)
+                                     expression[2], expression[3], entity_object)
 
     def __validate__(self):
         """

--- a/main/data_transformer/json_parser.py
+++ b/main/data_transformer/json_parser.py
@@ -36,7 +36,7 @@ class JsonParser(Parser):
             entities = data[self.config.entity_collection]
             fields = self.get_computable_fields()
             parsed_expressions = self.get_parsed_expression()
-            self.entityCollection.fields = list(fields) + [expression[3] for expression in self.get_parsed_expression()]
+            self.entityCollection.fields = list(fields) + [expression[2] for expression in self.get_parsed_expression()]
             for entity in entities:
                 entity_object = self.entityCollection.add_entity(entity.get(self.config.base_field))
                 self.__handle_normal_fields__(entity, fields, entity_object)
@@ -66,7 +66,7 @@ class JsonParser(Parser):
         """
         for expression in parsed_expressions:
             self.evaluate_expression(entity.get(expression[0]), entity.get(expression[1]),
-                                     expression[3], expression[4], entity_object)
+                                     expression[2], expression[3], entity_object)
 
     def __validate__(self):
         """

--- a/main/data_transformer/xml_parser.py
+++ b/main/data_transformer/xml_parser.py
@@ -34,7 +34,7 @@ class XmlParser(Parser):
         entities = root.findall(self.config.entity_collection)
         fields = self.get_computable_fields()
         parsed_expressions = self.get_parsed_expression()
-        self.entityCollection.fields = list(fields) + [expression[3] for expression in self.get_parsed_expression()]
+        self.entityCollection.fields = list(fields) + [expression[2] for expression in self.get_parsed_expression()]
         for entity in entities:
             entity_object = self.entityCollection.add_entity(entity.find(self.config.base_field).text)
             self.__handle_normal_fields__(entity, fields, entity_object)
@@ -64,7 +64,7 @@ class XmlParser(Parser):
         """
         for expression in parsed_expressions:
             self.evaluate_expression(entity.find(expression[0]).text, entity.find(expression[1]).text,
-                                     expression[3], expression[4], entity_object)
+                                     expression[2], expression[3], entity_object)
 
     def __validate__(self):
         """


### PR DESCRIPTION
1) Addressing the behavioral difference of regex package in different environments and compilers.

ISSUE:  In certain environment, after parsing 'A+B As C' returns A, B, C while in others it returns A, B, As, C. 
FIX: To address this, 'As' is checked and removed from list.

2) Added summary path